### PR TITLE
Added bangs to copyright

### DIFF
--- a/jquery.cookiebar.css
+++ b/jquery.cookiebar.css
@@ -1,3 +1,18 @@
+/*!
+ * Copyright (C) 2012 PrimeBox (info@primebox.co.uk)
+ * 
+ * This work is licensed under the Creative Commons
+ * Attribution 3.0 Unported License. To view a copy
+ * of this license, visit
+ * http://creativecommons.org/licenses/by/3.0/.
+ * 
+ * Documentation available at:
+ * http://www.primebox.co.uk/projects/cookie-bar/
+ * 
+ * When using this software you use it at your own risk. We hold
+ * no responsibility for any damage caused by using this plugin
+ * or the documentation provided.
+ */
 #cookie-bar {background:#111111; height:auto; min-height:24px; line-height:24px; color:#eeeeee; text-align:center; padding:3px 0; z-index: 10000;}
 #cookie-bar.fixed {position:fixed; top:0; left:0; width:100%;}
 #cookie-bar.fixed.bottom {bottom:0; top:auto;}

--- a/jquery.cookiebar.js
+++ b/jquery.cookiebar.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * Copyright (C) 2012 PrimeBox (info@primebox.co.uk)
  * 
  * This work is licensed under the Creative Commons


### PR DESCRIPTION
Bangs in the copyright should preserve the copyright banner in (most) minifiers. YMMV with regard to grunt.
